### PR TITLE
Switch to boto3, allow passing in of boto session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ to see if you need to scale your read/write units up or down.
 If you encounter any bugs, have questions, or would like to share an idea,
 hit up our `issue tracker`_.
 
-.. _Boto: https://github.com/boto/boto
+.. _Boto3: https://github.com/boto/boto3
 .. _issue tracker: https://github.com/gtaylor/django-dynamodb-sessions/issues
 
 Configuration
@@ -89,14 +89,25 @@ The following settings may be used in your ``settings.py``:
                                       This may lead to slightly slower queries,
                                       but you'll never miss object
                                       creation/edits. Defaults to ``True``.
+:DYNAMODB_SESSIONS_BOTO_SESSION: Used instead of providing access_key and
+                                 region, the `boto3.session.Session <http://boto3.readthedocs.org/en/latest/reference/core/session.html>`_
+                                 containing authentication for the AWS account
+                                 to use for DynamoDB.
 :DYNAMODB_SESSIONS_AWS_ACCESS_KEY_ID: The access key for the AWS account
                                       to use for DynamoDB.
 :DYNAMODB_SESSIONS_AWS_SECRET_ACCESS_KEY: The secret for the AWS account
                                           to use for DynamoDB.
 :DYNAMODB_SESSIONS_AWS_REGION_NAME: The region to use for DynamoDB.
 
+
 Changes
 -------
+
+0.7
+^^^
+
+* Switch to boto3 rather than boto for AWS access.
+* Allow passing of boto3 session rather than AWS credentials.
 
 0.6
 ^^^

--- a/dynamodb_sessions/__init__.py
+++ b/dynamodb_sessions/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'gtaylor'
 # Major, minor
-__version__ = (0, 6)
+__version__ = (0, 7)

--- a/dynamodb_sessions/tests.py
+++ b/dynamodb_sessions/tests.py
@@ -6,10 +6,10 @@ from .backends.cached_dynamodb import SessionStore as CachedDynamoDBSession
 
 
 class DynamoDBTestCase(SessionTestsMixin, TestCase):
-    
+
     backend = DynamoDBSession
-    
+
 
 class CachedDynamoDBTestCase(SessionTestsMixin, TestCase):
-    
+
     backend = CachedDynamoDBSession

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-boto
+boto3
+django

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='BSD License',
     url='https://github.com/gtaylor/django-dynamodb-sessions',
     platforms=["any"],
-    install_requires=['django', "boto>=2.2.2"],
+    install_requires=['django', "boto3>=1.1.4"],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
* also now correctly checks if a key already exists on must_create and throws CreateError

Not sure if it interests you, as far as I can tell functionality is unchanged, I needed to provide refreshable credentials and this seemed the easiest way. Especially since boto is slowly being depreciated